### PR TITLE
Fix pgrep iscsid race condition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ EOF
 WORKDIR /
 COPY --chmod=777 <<-"EOF" /csibin/nsenter.sh
 	#!/usr/bin/env bash
-	iscsid_pid=$(pgrep iscsid)
+	iscsid_pid=$(pgrep iscsid | head -n 1)
 	BIN="$(basename "$0")"
 	nsenter --mount="/proc/${iscsid_pid}/ns/mnt" --net="/proc/${iscsid_pid}/ns/net" -- "$BIN" "$@"
 EOF


### PR DESCRIPTION
I was getting an issue where `pgrep iscsid` sometimes returned 2 PIDs, which was causing nsenter to fail