### PR TITLE
fix: helm chart secret persistence

### DIFF
--- a/charts/synology-csi/templates/client-info.yaml
+++ b/charts/synology-csi/templates/client-info.yaml
@@ -1,5 +1,5 @@
 {{- with $.Values.clientInfoSecret }}
-{{- if and .create $.Release.IsInstall }}
+{{- if .create }}
 ---
 apiVersion: v1
 data:

--- a/charts/synology-csi/values.yaml
+++ b/charts/synology-csi/values.yaml
@@ -12,7 +12,7 @@ clientInfoSecret:
 #      password: password
 #      port: 5001
 #      username: username
-  # Whether to create the secret if the chart gets installed or not; ignored on updates.
+  # Whether to create the secret or not
   create: false
   # Defaults to {{ include "synology-csi.fullname" $ }}-client-info if empty or not present:
   name: "client-info-secret"


### PR DESCRIPTION
The client-info secret is deleted by helm when a chart is upgraded. This is especially cumbersome when using declarative tools like helmsmans:

```
$ helmsman -f helmsman2.yaml --show-diff  --show-secrets

 _          _
| |        | |
| |__   ___| |_ __ ___  ___ _ __ ___   __ _ _ __
| '_ \ / _ \ | '_ ` _ \/ __| '_ ` _ \ / _` | '_ \
| | | |  __/ | | | | | \__ \ | | | | | (_| | | | |
|_| |_|\___|_|_| |_| |_|___/_| |_| |_|\__,_|_| |_| version: v3.17.0
A Helm-Charts-as-Code tool.

2024-05-29 22:35:31 INFO: validating environment variables in helmsman2.yaml
2024-05-29 22:35:31 INFO: Parsed [[ helmsman2.yaml ]] successfully and found [ 1 ] apps
2024-05-29 22:35:31 INFO: Validating desired state definition
2024-05-29 22:35:31 INFO: Setting up kubectl
2024-05-29 22:35:31 INFO: Setting up helm
2024-05-29 22:35:32 INFO: Getting chart information
2024-05-29 22:35:33 INFO: Charts validated.
2024-05-29 22:35:33 INFO: Preparing plan
2024-05-29 22:35:33 INFO: Acquiring current Helm state from cluster
synology-csi, client-info-secret, Secret (v1) has been removed:
- # Source: synology-csi/templates/client-info.yaml
- apiVersion: v1
- kind: Secret
- metadata:
-   labels:
-     app.kubernetes.io/instance: synology-csi
-     app.kubernetes.io/managed-by: Helm
-     app.kubernetes.io/name: synology-csi
-     app.kubernetes.io/version: v1.1.2
-     helm.sh/chart: synology-csi-0.9.3
-     helm.sh/template: client-info.yaml
-   name: client-info-secret
- data:
-   client-info.yml: '-------- # (110 bytes)'
2024-05-29 22:35:34 INFO: Checking if any Helmsman managed releases are no longer tracked by your desired state ...
2024-05-29 22:35:34 INFO: No untracked releases found
2024-05-29 22:35:34 NOTICE: -------- PLAN starts here --------------
2024-05-29 22:35:34 NOTICE: Release [ synology-csi ] will be updated -- priority: 0
2024-05-29 22:35:34 NOTICE: -------- PLAN ends here --------------
```

I believe the original intention is for helm to create the secret on install, using the `IsInstall` flag, and ignore it afterwards. Unfortunately, that isn't how helm works, and if the resource is not rendered on upgrade, it will actually be removed.