### PR TITLE
fix: snapshotter role need `patch` permission on VSC too

### DIFF
--- a/charts/synology-csi/templates/snapshotter.yaml
+++ b/charts/synology-csi/templates/snapshotter.yaml
@@ -22,7 +22,7 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents" ]
-    verbs: [ "create", "get", "list", "watch", "update", "delete" ]
+    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update" ]

--- a/charts/synology-csi/templates/volumesnapshotclass.yaml
+++ b/charts/synology-csi/templates/volumesnapshotclass.yaml
@@ -10,7 +10,7 @@ driver: csi.san.synology.com
 kind: VolumeSnapshotClass
 metadata:
   annotations:
-    snapshot.storageclass.kubernetes.io/is-default-class: {{ default "false" .isDefault | quote }}
+    snapshot.storage.kubernetes.io/is-default-class: {{ default "false" .isDefault | quote }}
   labels: {{- include "synology-csi.labels" $ | nindent 4 }}
   name: {{ $name }}
 {{- with .parameters }}


### PR DESCRIPTION
It is not be able to update the VSC with this error
```
Failed to create snapshot: failed to add VolumeSnapshotBeingCreated annotation on the content snapcontent-96a3ac4a-a593-494c-9684-f747af62353f: "snapshot controller failed to update snapcontent-96a3ac4a-a593-494c-9684-f747af62353f on API server: volumesnapshotcontents.snapshot.storage.k8s.io \"snapcontent-96a3ac4a-a593-494c-9684-f747af62353f\" is forbidden: User \"system:serviceaccount:kube-system:synology-csi-snapshotter\" cannot patch resource \"volumesnapshotcontents\" in API group \"snapshot.storage.k8s.io\" at the cluster scope"
```

Also correct the default annotation for snapshot class https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes/#the-volumesnapshotclass-resource