### PR TITLE
update image customization options to support automatic upgrades

### DIFF
--- a/charts/synology-csi/templates/controller.yaml
+++ b/charts/synology-csi/templates/controller.yaml
@@ -101,7 +101,7 @@ spec:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           {{- with .provisioner }}
-          image: {{ .image }}:{{ .tag }}
+          image: {{ .image.repository }}:{{ .image.tag }}
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           securityContext:
@@ -120,7 +120,7 @@ spec:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           {{- with .attacher }}
-          image: {{ .image }}:{{ .tag }}
+          image: {{ .image.repository }}:{{ .image.tag }}
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           securityContext:
@@ -139,7 +139,7 @@ spec:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           {{- with .resizer }}
-          image: {{ .image }}:{{ .tag }}
+          image: {{ .image.repository }}:{{ .image.tag }}
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           securityContext:
@@ -160,7 +160,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
           {{- with .plugin }}
-          image: {{ .image }}:{{ .tag | default $.Chart.AppVersion }}
+          image: {{ .image.repository }}:{{ .image.tag | default $.Chart.AppVersion }}
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           securityContext:

--- a/charts/synology-csi/templates/node.yaml
+++ b/charts/synology-csi/templates/node.yaml
@@ -85,7 +85,7 @@ spec:
             - name: REGISTRATION_PATH
               value: {{ $.Values.node.kubeletPath }}/plugins/csi.san.synology.com/csi.sock
           {{- with .nodeDriverRegistrar }}
-          image: {{ .image }}:{{ .tag }}
+          image: {{ .image.repository }}:{{ .image.tag }}
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           securityContext:
@@ -109,7 +109,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           {{- with .plugin }}
-          image: {{ .image }}:{{ .tag | default $.Chart.AppVersion }}
+          image: {{ .image.repository }}:{{ .image.tag | default $.Chart.AppVersion }}
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           securityContext:

--- a/charts/synology-csi/values.yaml
+++ b/charts/synology-csi/values.yaml
@@ -24,30 +24,36 @@ controller:
 fullnameOverride: ""
 images:
   attacher:
-    image: registry.k8s.io/sig-storage/csi-attacher
     pullPolicy: IfNotPresent
-    tag: v4.2.0
+    image:
+      repository: registry.k8s.io/sig-storage/csi-attacher
+      tag: v4.2.0
   nodeDriverRegistrar:
-    image: registry.k8s.io/sig-storage/csi-node-driver-registrar
     pullPolicy: IfNotPresent
-    tag: v2.6.3
+    image:
+      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
+      tag: v2.6.3
   plugin:
-    image: ghcr.io/zebernst/synology-csi
     pullPolicy: IfNotPresent
-    # Defaults to {{ $.Chart.AppVersion }} if empty or not present:
-    tag: ""
+    image:
+      repository: ghcr.io/zebernst/synology-csi
+      # Defaults to {{ $.Chart.AppVersion }} if empty or not present:
+      tag: ""
   provisioner:
-    image: registry.k8s.io/sig-storage/csi-provisioner
     pullPolicy: IfNotPresent
-    tag: v3.4.0
+    image:
+      repository: registry.k8s.io/sig-storage/csi-provisioner
+      tag: v3.4.0
   resizer:
-    image: registry.k8s.io/sig-storage/csi-resizer
     pullPolicy: IfNotPresent
-    tag: v1.7.0
+    image:
+      repository: registry.k8s.io/sig-storage/csi-resizer
+      tag: v1.7.0
   snapshotter:
-    image: registry.k8s.io/sig-storage/csi-snapshotter
     pullPolicy: IfNotPresent
-    tag: v4.2.1
+    image:
+      repository: registry.k8s.io/sig-storage/csi-snapshotter
+      tag: v4.2.1
 installCSIDriver: true
 nameOverride: ""
 # Specifies affinity, nodeSelector and tolerations for the node DaemonSet


### PR DESCRIPTION
Is it possible to restructure the `image` option in the Helm chart values to something like this?

```yaml
images:
  plugin:
    image:
      repository: ghcr.io/zebernst/synology-csi
      tag: 1.2.0 
```

I believe this will help people who use tools such as [Renovate](https://docs.renovatebot.com/modules/manager/helm-values/#additional-information) to automatically PR newer container versions as they become available. This PR suggestion matches closer to the conventional format used in many helm charts.