### PR TITLE
Make test container/pvc optional & bump

### DIFF
--- a/charts/synology-csi/Chart.yaml
+++ b/charts/synology-csi/Chart.yaml
@@ -9,4 +9,4 @@ kubeVersion: ">= 1.20.0"
 sources:
   - https://github.com/zebernst/synology-csi-talos/tree/main
   - https://github.com/SynologyOpenSource/synology-csi/tree/main
-version: 0.9.5-pre.1
+version: 0.9.5-pre.2

--- a/charts/synology-csi/templates/test.yaml
+++ b/charts/synology-csi/templates/test.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.test.enabled }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -7,14 +8,14 @@ metadata:
     helm.sh/hook-delete-policy: hook-succeeded
   labels: {{- include "synology-csi.labels" $ | nindent 4 }}
   name: {{ include "synology-csi.fullname" $ }}-test
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: synology-iscsi-storage-delete
+  storageClassName: {{ .Values.test.storageClass }}
   resources:
     requests:
       storage: 1Gi
-
 ---
 apiVersion: batch/v1
 kind: Job
@@ -26,6 +27,7 @@ metadata:
     app: test
     {{- include "synology-csi.labels" $ | nindent 4 }}
   name: {{ include "synology-csi.fullname" $ }}-test
+  namespace: {{ .Release.Namespace }}
 spec:
   template:
     metadata:
@@ -46,3 +48,4 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "synology-csi.fullname" $ }}-test
+{{- end }}

--- a/charts/synology-csi/values.yaml
+++ b/charts/synology-csi/values.yaml
@@ -101,3 +101,6 @@ volumeSnapshotClasses: {}
     ##parameters:
     ##  description: "Kubernetes CSI"
     ##  is_locked: "false"
+test:
+  enabled: true
+  storageClass: synology-iscsi-storage-delete


### PR DESCRIPTION
# Context

Currently the test job and pvc are hardcoded. Any deviation from the standard storage class name will result in an error when deploying the chart.

# Proposal

* Make the test container optional and slightly configureable so we can specify the storageclass
* No-break change on the chart, defaults will simulate the original behavior