### PR TITLE
Feature/try to fix iscsi

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/zebernst/synology-csi
+          images: ghcr.io/mortalflesh/synology-csi
           tags: |
             type=semver,prefix=v,pattern={{version}}
             type=semver,prefix=v,pattern={{major}}.{{minor}}
@@ -41,7 +41,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=edge
-          labels: org.opencontainers.image.source=https://github.com/zebernst/synology-csi-talos
+          labels: org.opencontainers.image.source=https://github.com/mortalflesh/synology-csi-talos
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,86 @@ ENV PATH="/csibin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 # Copy and run CSI driver
 COPY --from=builder /go/src/synok8scsiplugin/synology-csi-driver /synology-csi-driver
 
-ENTRYPOINT ["/synology-csi-driver"]
+# Create entrypoint script that starts iscsid before the CSI driver
+COPY --chmod=755 <<-"EOF" /entrypoint.sh
+	#!/bin/bash
+	set -e
+
+	# Check if we're running as a node pod (node pods have --nodeid with actual node name, not "NotUsed")
+	if [[ "$*" == *"--nodeid"* ]] && [[ "$*" != *"--nodeid=NotUsed"* ]]; then
+		echo "Detected node pod - initializing iSCSI daemon..."
+		
+		# Create necessary directories for iscsid
+		mkdir -p /etc/iscsi
+		mkdir -p /var/lib/iscsi/nodes
+		mkdir -p /var/lib/iscsi/send_targets
+		mkdir -p /var/lib/iscsi/static
+		mkdir -p /var/lib/iscsi/isns
+		mkdir -p /var/lib/iscsi/slp
+		mkdir -p /var/lock/iscsi
+
+		# Create basic iscsid configuration if it doesn't exist
+		if [ ! -f /etc/iscsi/iscsid.conf ]; then
+			echo "Creating basic iscsid.conf..."
+			cat > /etc/iscsi/iscsid.conf << 'ISCSICONF'
+# Basic iscsid configuration
+iscsid.startup = /etc/rc.d/init.d/iscsid force-start
+iscsid.safe_logout = Yes
+node.startup = automatic
+node.leading_login = No
+node.conn[0].timeo.login_timeout = 15
+node.conn[0].timeo.logout_timeout = 15
+node.conn[0].timeo.noop_out_interval = 5
+node.conn[0].timeo.noop_out_timeout = 5
+node.session.timeo.replacement_timeout = 120
+node.session.err_timeo.abort_timeout = 15
+node.session.err_timeo.lu_reset_timeout = 30
+node.session.err_timeo.tgt_reset_timeout = 30
+node.session.initial_login_retry_max = 8
+node.session.cmds_max = 128
+node.session.queue_depth = 32
+node.session.xmit_thread_priority = -20
+node.session.iscsi.InitialR2T = No
+node.session.iscsi.ImmediateData = Yes
+node.session.iscsi.FirstBurstLength = 262144
+node.session.iscsi.MaxBurstLength = 16776192
+node.conn[0].iscsi.MaxRecvDataSegmentLength = 262144
+node.conn[0].iscsi.MaxXmitDataSegmentLength = 0
+discovery.sendtargets.iscsi.MaxRecvDataSegmentLength = 32768
+node.conn[0].iscsi.HeaderDigest = None
+node.session.nr_sessions = 1
+node.session.iscsi.FastAbort = Yes
+ISCSICONF
+		fi
+
+		# Start iscsid daemon in background
+		echo "Starting iscsid daemon..."
+		if /usr/sbin/iscsid -d 8 -f &
+		then
+			ISCSID_PID=$!
+			echo "iscsid started with PID $ISCSID_PID"
+			
+			# Wait a moment for iscsid to initialize
+			sleep 2
+			
+			# Verify iscsid is still running
+			if kill -0 $ISCSID_PID 2>/dev/null; then
+				echo "iscsid daemon started successfully"
+			else
+				echo "Error: iscsid daemon failed to start properly"
+				exit 1
+			fi
+		else
+			echo "Error: Failed to start iscsid daemon"
+			exit 1
+		fi
+	else
+		echo "Detected controller pod - skipping iSCSI daemon initialization"
+	fi
+
+	# Start the main CSI driver
+	echo "Starting Synology CSI driver..."
+	exec /synology-csi-driver "$@"
+EOF
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN <<-EOF
 		e2fsprogs \
 		e2fsprogs-extra \
 		nfs-utils \
+		open-iscsi \
 		iproute2 \
 		util-linux \
 		xfsprogs \
@@ -44,6 +45,10 @@ WORKDIR /
 COPY --chmod=777 <<-"EOF" /csibin/nsenter.sh
 	#!/usr/bin/env bash
 	iscsid_pid=$(pgrep iscsid | head -n 1)
+	if [ -z "$iscsid_pid" ]; then
+		echo "Error: iscsid process not found" >&2
+		exit 1
+	fi
 	BIN="$(basename "$0")"
 	nsenter --mount="/proc/${iscsid_pid}/ns/mnt" --net="/proc/${iscsid_pid}/ns/net" -- "$BIN" "$@"
 EOF

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 #  Copyright 2021 Synology Inc.
 
-REGISTRY_NAME=ghcr.io/zebernst
+REGISTRY_NAME=ghcr.io/mortalflesh
 IMAGE_NAME=synology-csi
-IMAGE_VERSION=v1.2.0
+IMAGE_VERSION=v1.2.1
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 
 # For now, only build linux/amd64 platform
@@ -22,7 +22,7 @@ synology-csi-driver:
 	$(BUILD_ENV) go build -v -ldflags $(BUILD_FLAGS) -o ./bin/synology-csi-driver ./
 
 docker-build:
-	docker buildx build -t $(IMAGE_TAG) . --push
+	docker buildx build -t $(IMAGE_TAG) --platform linux/amd64 . --push
 
 docker-build-multiarch:
 	docker buildx build -t $(IMAGE_TAG) --platform linux/amd64,linux/arm/v7,linux/arm64 . --push

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 REGISTRY_NAME=ghcr.io/mortalflesh
 IMAGE_NAME=synology-csi
-IMAGE_VERSION=v1.2.1
+IMAGE_VERSION=v1.2.5
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 
 # For now, only build linux/amd64 platform

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository also includes a [Helm chart](./charts/synology-csi) for convenie
 Driver Name: csi.san.synology.com
 | Driver Version                                                                   | Image                                                                 | Supported K8s Version |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------------------- | --------------------- |
-| [v1.2.0](https://github.com/SynologyOpenSource/synology-csi/tree/release-v1.2.0) | [synology-csi:v1.2.0](https://hub.docker.com/r/synology/synology-csi) | 1.20+                 |
+| [v1.2.1](https://github.com/SynologyOpenSource/synology-csi/tree/release-v1.2.1) | [synology-csi:v1.2.1](https://hub.docker.com/r/synology/synology-csi) | 1.20+                 |
 
 
 
@@ -35,7 +35,7 @@ The Synology CSI driver supports:
 3. After you complete the steps below, the *full* deployment of the CSI driver, including the snapshotter, will be installed. If you don’t need the **Snapshot** feature, you can install the *basic* deployment of the CSI driver instead.
 
 ### Procedure
-1. Clone the git repository. `git clone https://github.com/zebernst/synology-csi-talos.git`
+1. Clone the git repository. `git clone https://github.com/mortalflesh/synology-csi-talos.git`
 2. Enter the directory. `cd synology-csi`
 3. Copy the client-info-template.yml file. `cp config/client-info-template.yml config/client-info.yml`
 4. Edit `config/client-info.yml` to configure the connection information for DSM. You can specify **one or more** storage systems on which the CSI volumes will be created. Change the following parameters as needed:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository also includes a [Helm chart](./charts/synology-csi) for convenie
 Driver Name: csi.san.synology.com
 | Driver Version                                                                   | Image                                                                 | Supported K8s Version |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------------------- | --------------------- |
-| [v1.2.1](https://github.com/SynologyOpenSource/synology-csi/tree/release-v1.2.1) | [synology-csi:v1.2.1](https://hub.docker.com/r/synology/synology-csi) | 1.20+                 |
+| [v1.2.5](https://github.com/SynologyOpenSource/synology-csi/tree/release-v1.2.5) | [synology-csi:v1.2.5](https://hub.docker.com/r/synology/synology-csi) | 1.20+                 |
 
 
 

--- a/charts/synology-csi/Chart.yaml
+++ b/charts/synology-csi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.2.1
+appVersion: v1.2.5
 name: synology-csi
 description: A Helm chart for the Synology CSI Driver
 keywords:

--- a/charts/synology-csi/Chart.yaml
+++ b/charts/synology-csi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.2.0
+appVersion: v1.2.1
 name: synology-csi
 description: A Helm chart for the Synology CSI Driver
 keywords:
@@ -7,6 +7,6 @@ keywords:
   - CSI Driver
 kubeVersion: ">= 1.20.0"
 sources:
-  - https://github.com/zebernst/synology-csi-talos/tree/main
+  - https://github.com/mortalflesh/synology-csi-talos/tree/main
   - https://github.com/SynologyOpenSource/synology-csi/tree/main
 version: 0.9.5-pre.4

--- a/charts/synology-csi/README.md
+++ b/charts/synology-csi/README.md
@@ -29,7 +29,7 @@ issues and to benefit from the advanced resource management features of Helm.
 
 Once Helm has been set up correctly, add the repo as follows:
 
-    helm repo add synology-csi-chart https://zebernst.github.io/synology-csi-talos
+    helm repo add synology-csi-chart https://mortalflesh.github.io/synology-csi-talos
 
 If you had already added this repo earlier, run `helm repo update` to retrieve the latest versions of the packages.
 You can then run `helm search repo synology-csi-chart` to see the charts.

--- a/charts/synology-csi/templates/controller.yaml
+++ b/charts/synology-csi/templates/controller.yaml
@@ -176,6 +176,10 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy
       {{- end }}
       hostNetwork: true
+      {{- with $.Values.images.plugin.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/synology-csi/templates/node.yaml
+++ b/charts/synology-csi/templates/node.yaml
@@ -129,6 +129,10 @@ spec:
               mountPath: /csi
       {{- end }}
       hostNetwork: true
+      {{- with $.Values.images.plugin.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/synology-csi/values.yaml
+++ b/charts/synology-csi/values.yaml
@@ -36,9 +36,11 @@ images:
   plugin:
     pullPolicy: IfNotPresent
     image:
-      repository: ghcr.io/zebernst/synology-csi
+      repository: ghcr.io/mortalflesh/synology-csi
       # Defaults to {{ $.Chart.AppVersion }} if empty or not present:
-      tag: ""
+      tag: "v1.2.1"
+      imagePullSecrets:
+        - name: ghcr-secret
   provisioner:
     pullPolicy: IfNotPresent
     image:

--- a/charts/synology-csi/values.yaml
+++ b/charts/synology-csi/values.yaml
@@ -38,7 +38,7 @@ images:
     image:
       repository: ghcr.io/mortalflesh/synology-csi
       # Defaults to {{ $.Chart.AppVersion }} if empty or not present:
-      tag: "v1.2.1"
+      tag: "v1.2.5"
       imagePullSecrets:
         - name: ghcr-secret
   provisioner:

--- a/deploy/kubernetes/v1.19/controller.yml
+++ b/deploy/kubernetes/v1.19/controller.yml
@@ -144,7 +144,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: synology/synology-csi:v1.2.0
+          image: synology/synology-csi:v1.2.1
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.19/controller.yml
+++ b/deploy/kubernetes/v1.19/controller.yml
@@ -144,7 +144,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: synology/synology-csi:v1.2.1
+          image: synology/synology-csi:v1.2.5
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.19/node.yml
+++ b/deploy/kubernetes/v1.19/node.yml
@@ -86,7 +86,7 @@ spec:
           securityContext:
             privileged: true
           imagePullPolicy: IfNotPresent
-          image: synology/synology-csi:v1.2.0
+          image: synology/synology-csi:v1.2.1
           args:
             - --nodeid=$(KUBE_NODE_NAME)
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.19/node.yml
+++ b/deploy/kubernetes/v1.19/node.yml
@@ -86,7 +86,7 @@ spec:
           securityContext:
             privileged: true
           imagePullPolicy: IfNotPresent
-          image: synology/synology-csi:v1.2.1
+          image: synology/synology-csi:v1.2.5
           args:
             - --nodeid=$(KUBE_NODE_NAME)
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.19/snapshotter/snapshotter.yaml
+++ b/deploy/kubernetes/v1.19/snapshotter/snapshotter.yaml
@@ -81,7 +81,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: synology/synology-csi:v1.2.0
+          image: synology/synology-csi:v1.2.1
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.19/snapshotter/snapshotter.yaml
+++ b/deploy/kubernetes/v1.19/snapshotter/snapshotter.yaml
@@ -81,7 +81,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: synology/synology-csi:v1.2.1
+          image: synology/synology-csi:v1.2.5
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.20/controller.yml
+++ b/deploy/kubernetes/v1.20/controller.yml
@@ -146,7 +146,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: ghcr.io/mortalflesh/synology-csi:v1.2.1
+          image: ghcr.io/mortalflesh/synology-csi:v1.2.5
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.20/controller.yml
+++ b/deploy/kubernetes/v1.20/controller.yml
@@ -84,6 +84,8 @@ spec:
     spec:
       serviceAccountName: csi-controller-sa
       hostNetwork: true
+      imagePullSecrets:
+        - name: ghcr-secret
       containers:
         - name: csi-provisioner
           securityContext:
@@ -144,7 +146,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: ghcr.io/zebernst/synology-csi:v1.2.0
+          image: ghcr.io/mortalflesh/synology-csi:v1.2.1
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.20/node.yml
+++ b/deploy/kubernetes/v1.20/node.yml
@@ -59,6 +59,8 @@ spec:
       hostPID: true
       serviceAccount: csi-node-sa
       hostNetwork: true
+      imagePullSecrets:
+        - name: ghcr-secret
       containers:
         - name: csi-driver-registrar
           securityContext:
@@ -87,7 +89,7 @@ spec:
           securityContext:
             privileged: true
           imagePullPolicy: IfNotPresent
-          image: ghcr.io/zebernst/synology-csi:v1.2.0
+          image: ghcr.io/mortalflesh/synology-csi:v1.2.1
           args:
             - --nodeid=$(KUBE_NODE_NAME)
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.20/node.yml
+++ b/deploy/kubernetes/v1.20/node.yml
@@ -89,7 +89,7 @@ spec:
           securityContext:
             privileged: true
           imagePullPolicy: IfNotPresent
-          image: ghcr.io/mortalflesh/synology-csi:v1.2.1
+          image: ghcr.io/mortalflesh/synology-csi:v1.2.5
           args:
             - --nodeid=$(KUBE_NODE_NAME)
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.20/snapshotter/snapshotter.yaml
+++ b/deploy/kubernetes/v1.20/snapshotter/snapshotter.yaml
@@ -57,6 +57,8 @@ spec:
     spec:
       serviceAccountName: csi-snapshotter-sa
       hostNetwork: true
+      imagePullSecrets:
+        - name: ghcr-secret
       containers:
         - name: csi-snapshotter
           securityContext:
@@ -81,7 +83,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: ghcr.io/zebernst/synology-csi:v1.2.0
+          image: ghcr.io/mortalflesh/synology-csi:v1.2.1
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.20/snapshotter/snapshotter.yaml
+++ b/deploy/kubernetes/v1.20/snapshotter/snapshotter.yaml
@@ -83,7 +83,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: ghcr.io/mortalflesh/synology-csi:v1.2.1
+          image: ghcr.io/mortalflesh/synology-csi:v1.2.5
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -74,7 +74,7 @@ case "$1" in
         csi_install
         ;;
     run)
-        csi_build
+        #csi_build
         csi_install
         ;;
     *)


### PR DESCRIPTION
Currently it is not working for me
- nfs works
- iscsi does not

With Copilot/Claude we tried a few things, leading to v1.2.5 image, pods are running, there is no `iscsi process not found` error, but it still doesnt work.

### The Problem (for future reference)
- iSCSI with Synology CSI on Talos Linux has known issues with the nsenter approach
- Hundreds of hanging iscsiadm processes are created because the nsenter wrapper script doesn't work properly on Talos
- Test pods get stuck in ContainerCreating due to volume mount timeouts (context deadline exceeded)
- Your own README already documents this: "Known issue with Synology CSI driver on Talos Linux. Use NFS storage instead."

### Root Cause
The Synology CSI driver tries to use nsenter to run iSCSI commands in the host namespace, but this approach is problematic on Talos Linux, leading to process hangs and mount failures.

---
There is also this issue: https://github.com/zebernst/synology-csi-talos/issues/21
